### PR TITLE
세션 정보와 타임아웃 설정

### DIFF
--- a/login-start/src/main/java/hello/login/web/session/SessionInfoController.java
+++ b/login-start/src/main/java/hello/login/web/session/SessionInfoController.java
@@ -1,0 +1,35 @@
+package hello.login.web.session;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+import java.util.Date;
+
+@Slf4j
+@RestController
+public class SessionInfoController {
+
+    @GetMapping("/session-info")
+    public String sessionInfo(HttpServletRequest request) {
+
+        HttpSession session = request.getSession(false);
+        if (session == null) {
+            return "세션이 없습니다.";
+        }
+
+        // 세션 데이터 출력
+        session.getAttributeNames().asIterator()
+                .forEachRemaining(name -> log.info("session name={}, value={}", name, session.getAttribute(name)));
+
+        log.info("sessionId={}", session.getId());
+        log.info("MaxInactiveInterval={}", session.getMaxInactiveInterval());
+        log.info("creationTime={}", new Date(session.getCreationTime()));
+        log.info("lastAccessedTime={}", new Date(session.getLastAccessedTime()));
+        log.info("isNew={}",  session.isNew());
+
+        return "세션 출력";
+    }
+}


### PR DESCRIPTION
- sessionId : 세션Id, JSESSIONID 의 값이다. 예) 34B14F008AA3527C9F8ED620EFD7A4E1
- maxInactiveInterval : 세션의 유효 시간, 예) 1800초, (30분)
- creationTime : 세션 생성일시
- lastAccessedTime : 세션과 연결된 사용자가 최근에 서버에 접근한 시간, 클라이언트에서 서버로
- sessionId ( JSESSIONID )를 요청한 경우에 갱신된다.
- isNew : 새로 생성된 세션인지, 아니면 이미 과거에 만들어졌고, 클라이언트에서 서버로
- sessionId ( JSESSIONID )를 요청해서 조회된 세션인지 여부


## 세션 타임아웃 설정
- 스프링 부트로 글로벌 설정
application.properties
server.servlet.session.timeout=60 : 60초, 기본은 1800(30분)
(글로벌 설정은 분 단위로 설정해야 한다. 60(1분), 120(2분), ...)
- 특정 세션 단위로 시간 설정
session.setMaxInactiveInterval(1800); //1800초

