### PR TITLE
스프링 인터셉터 - 요청 로그

### DIFF
--- a/login-start/src/main/java/hello/login/WebConfig.java
+++ b/login-start/src/main/java/hello/login/WebConfig.java
@@ -2,16 +2,27 @@ package hello.login;
 
 import hello.login.web.filter.LogFilter;
 import hello.login.web.filter.LoginCheckFilter;
+import hello.login.web.interceptor.LogInterceptor;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import javax.servlet.Filter;
 
 @Configuration
-public class WebConfig {
+public class WebConfig implements WebMvcConfigurer {
 
-    @Bean
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new LogInterceptor())
+                .order(1)
+                .addPathPatterns("/**")
+                .excludePathPatterns("/css/**", "/*.ico", "/error");
+    }
+
+//    @Bean
     public FilterRegistrationBean logFilter() {
         FilterRegistrationBean<Filter> filterRegistrationBean = new FilterRegistrationBean<>();
         filterRegistrationBean.setFilter(new LogFilter());

--- a/login-start/src/main/java/hello/login/web/interceptor/LogInterceptor.java
+++ b/login-start/src/main/java/hello/login/web/interceptor/LogInterceptor.java
@@ -1,0 +1,48 @@
+package hello.login.web.interceptor;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.ModelAndView;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.UUID;
+
+@Slf4j
+public class LogInterceptor implements HandlerInterceptor {
+
+    public static final String LOG_ID = "logId";
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+
+        String requestURI = request.getRequestURI();
+
+        String uuid = UUID.randomUUID().toString();
+        request.setAttribute(LOG_ID, uuid);
+
+        // @RequestMapping : HandlerMethod
+        // 정적 리소스 : ResourceHttpRequestHandler
+        if (handler instanceof HandlerMethod) {
+            HandlerMethod hm = (HandlerMethod) handler; // 호출할 컨트롤러 메서드의 모든 정보가 포함되어 있다.
+        }
+
+        log.info("REQUEST    [{}][{}][{}]", uuid, requestURI, handler);
+        return true;    // false 진행X
+    }
+
+    @Override
+    public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler, ModelAndView modelAndView) throws Exception {
+        log.info("postHandle  [{}]", modelAndView);
+    }
+
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) throws Exception {
+        String requestURI = request.getRequestURI();
+        String logId = (String) request.getAttribute(LOG_ID);
+        log.info("RESPONSE  [{}][{}]", logId, requestURI);
+        if (ex != null) {
+            log.error("afterCompletion error!!", ex);
+        }
+    }
+}

--- a/login-start/src/main/java/hello/login/web/item/ItemController.java
+++ b/login-start/src/main/java/hello/login/web/item/ItemController.java
@@ -102,5 +102,4 @@ public class ItemController {
         itemRepository.update(itemId, itemParam);
         return "redirect:/items/{itemId}";
     }
-
 }


### PR DESCRIPTION
#### LogInterceptor - 요청 로그 인터셉터

-  String uuid = UUID.randomUUID().toString()
요청 로그를 구분하기 위한 uuid 를 생성한다.

- request.setAttribute(LOG_ID, uuid)
서블릿 필터의 경우 지역변수로 해결이 가능하지만, 스프링 인터셉터는 호출 시점이 완전히 분리되어
있다. 따라서 preHandle 에서 지정한 값을 postHandle , afterCompletion 에서 함께 사용하려면
어딘가에 담아두어야 한다. LogInterceptor 도 싱글톤 처럼 사용되기 때문에 맴버변수를 사용하면
위험하다. 따라서 request 에 담아두었다. 이 값은 afterCompletion 에서
request.getAttribute(LOG_ID) 로 찾아서 사용한다.

- return true
true 면 정상 호출이다. 다음 인터셉터나 컨트롤러가 호출된다.

#### HandlerMethod
핸들러 정보는 어떤 핸들러 매핑을 사용하는가에 따라 달라진다. 스프링을 사용하면 일반적으로
@Controller , @RequestMapping 을 활용한 핸들러 매핑을 사용하는데, 이 경우 핸들러 정보로
HandlerMethod 가 넘어온다.

#### ResourceHttpRequestHandler
- @Controller 가 아니라 /resources/static 와 같은 정적 리소스가 호출 되는 경우
ResourceHttpRequestHandler 가 핸들러 정보로 넘어오기 때문에 타입에 따라서 처리가 필요하다.

#### postHandle, afterCompletion
- 종료 로그를 postHandle 이 아니라 afterCompletion 에서 실행한 이유는, 예외가 발생한 경우
postHandle 가 호출되지 않기 때문이다. afterCompletion 은 예외가 발생해도 호출 되는 것을 보장한다.

#### WebMvcConfigurer 가 제공하는 addInterceptors() 를 사용해서 인터셉터를 등록할 수 있다.
- registry.addInterceptor(new LogInterceptor()) : 인터셉터를 등록한다.
- order(1) : 인터셉터의 호출 순서를 지정한다. 낮을 수록 먼저 호출된다.
- addPathPatterns("/**") : 인터셉터를 적용할 URL 패턴을 지정한다.
- excludePathPatterns("/css/**", "/*.ico", "/error") : 인터셉터에서 제외할 패턴을 지정한다.
=>필터와 비교해보면 인터셉터는 addPathPatterns , excludePathPatterns 로 매우 정밀하게 URL패턴을 지정할 수 있다.